### PR TITLE
feat: add static construction site starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# construction-template
-construction template website
+# Construction Template (Static Starter)
+
+A fast, accessible, mobile‑first construction website template. No build step—just HTML, CSS, and a tiny bit of JS. Optimized for Vercel.
+
+**Sections:** Hero, Services, Projects, Testimonials, Contact.  
+**Extras:** `vercel.json` with clean URLs and cache headers, `robots.txt`, `sitemap.xml`, and a PR template.
+
+## Quick Start
+
+```bash
+# clone and create a feature branch
+git clone https://github.com/gmena82/construction-template.git
+cd construction-template
+git checkout -b feat/site-starter
+
+# copy files from this starter into the repo root (or use the patch provided in the PR)
+# ... then commit & push
+git add -A
+git commit -m "feat: add static construction site starter"
+git push -u origin feat/site-starter
+```
+Open a PR to `main`. If your repo is connected to Vercel, the PR will get a Preview deployment automatically.
+
+## Customize
+
+- Update branding in `index.html` and colors in `css/styles.css`.
+- Replace placeholder project images (the gradient blocks) with your images.
+- Wire up the contact form by setting a real `action` URL (e.g., Formspree or a serverless function).
+
+## Production headers (Vercel)
+
+Static assets are served with `Cache-Control: public, max-age=31536000, immutable` via `vercel.json`. You can adjust headers or add rewrites/redirects if needed.
+
+## License
+
+MIT © You

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,122 @@
+/* Basic reset & variables */
+* { box-sizing: border-box; }
+:root {
+  --bg: #0f1216;
+  --surface: #141922;
+  --muted: #8b93a7;
+  --text: #e8ecf3;
+  --brand: #1f8cff;
+  --brand-2: #00c2a8;
+  --shadow: 0 10px 30px rgba(0,0,0,.3);
+  --radius: 14px;
+}
+
+html, body { height: 100%; scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.container { max-width: 1100px; margin: 0 auto; padding: 0 20px; }
+.section { padding: 72px 0; }
+.section-title { font-size: 2rem; margin: 0 0 8px; }
+.section-lead { color: var(--muted); margin: 0 0 28px; }
+
+/* Header */
+.skip-link {
+  position: absolute; left: -999px; top: -999px;
+  background: var(--brand); color: #000; padding: 8px 12px; border-radius: 6px;
+}
+.skip-link:focus { left: 16px; top: 16px; z-index: 1000; }
+
+.site-header {
+  position: sticky; top: 0; z-index: 50; backdrop-filter: saturate(120%) blur(6px);
+  background: rgba(15,18,22,.7); border-bottom: 1px solid rgba(255,255,255,.06);
+}
+.header-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.logo { color: var(--text); text-decoration: none; font-weight: 800; letter-spacing: .3px; }
+.logo span { color: var(--brand-2); }
+
+.site-nav { display: flex; align-items: center; gap: 24px; }
+.site-nav ul { display: flex; gap: 16px; list-style: none; margin: 0; padding: 0; }
+.site-nav a { color: var(--text); text-decoration: none; opacity: .9; }
+.site-nav a:hover { opacity: 1; }
+
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 16px; border-radius: 10px; border: 1px solid transparent; text-decoration: none; font-weight: 600; }
+.btn-primary { background: linear-gradient(90deg, var(--brand), var(--brand-2)); color: #001018; box-shadow: var(--shadow); }
+.btn-ghost { border-color: rgba(255,255,255,.16); color: var(--text); }
+
+.nav-toggle { display: none; background: transparent; border: 0; padding: 10px; border-radius: 10px; }
+.nav-toggle .bar { display: block; width: 22px; height: 2px; background: var(--text); margin: 5px 0; }
+
+/* Hero */
+.hero .grid-2 { display: grid; grid-template-columns: 1.2fr 1fr; gap: 32px; align-items: center; }
+.hero-copy h1 { font-size: clamp(2rem, 1.3rem + 3vw, 3rem); line-height: 1.1; margin: 0 0 10px; }
+.hero-copy p { color: var(--muted); margin: 0 0 20px; }
+.hero-cta { display: flex; gap: 12px; margin: 16px 0 8px; }
+.badges { display: flex; gap: 12px; padding: 0; list-style: none; color: var(--muted); flex-wrap: wrap; }
+
+.hero-media .hero-card { background: var(--surface); border: 1px solid rgba(255,255,255,.06); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); }
+.hero-media .hero-img { height: 280px; background: radial-gradient(60% 60% at 60% 40%, rgba(31,140,255,.35), transparent 60%), linear-gradient(180deg, #1c2533, #0f1216); }
+.hero-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; padding: 16px; }
+.hero-stats div { background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.06); border-radius: 10px; padding: 12px; text-align: center; }
+.hero-stats strong { display: block; font-size: 1.25rem; }
+
+/* Services */
+.cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.card { background: var(--surface); border: 1px solid rgba(255,255,255,.06); border-radius: var(--radius); padding: 20px; }
+.card h3 { margin: 0 0 8px; }
+.card p { margin: 0; color: var(--muted); }
+
+/* Projects */
+.gallery { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.project { margin: 0; }
+.placeholder { aspect-ratio: 4/3; border-radius: var(--radius); background:
+  radial-gradient(40% 40% at 20% 30%, rgba(0,194,168,.36), transparent 60%),
+  radial-gradient(30% 30% at 70% 60%, rgba(31,140,255,.28), transparent 60%),
+  linear-gradient(180deg, #1b2330, #121821);
+  border: 1px solid rgba(255,255,255,.06);
+}
+
+/* Testimonials */
+.quotes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+blockquote { margin: 0; padding: 16px; background: var(--surface); border: 1px solid rgba(255,255,255,.06); border-radius: var(--radius); color: var(--text); }
+blockquote footer { color: var(--muted); margin-top: 8px; }
+
+/* CTA */
+.cta .grid-2 { display: grid; grid-template-columns: 1.5fr .5fr; gap: 16px; align-items: center; background: linear-gradient(90deg, rgba(31,140,255,.15), rgba(0,194,168,.18)); border: 1px solid rgba(255,255,255,.08); border-radius: var(--radius); padding: 28px; }
+.cta-actions { text-align: right; }
+
+/* Contact */
+.form { background: var(--surface); border: 1px solid rgba(255,255,255,.06); border-radius: var(--radius); padding: 20px; }
+.fields { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.field.full { grid-column: 1 / -1; }
+label { display: block; font-weight: 600; margin-bottom: 6px; }
+input, textarea { width: 100%; padding: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.08); background: #0c1016; color: var(--text); }
+input::placeholder, textarea::placeholder { color: #8a93a7; }
+.form-actions { display: flex; align-items: center; gap: 16px; margin-top: 12px; }
+.form-note { color: var(--muted); margin: 0; }
+
+/* Footer */
+.site-footer { padding: 40px 0; border-top: 1px solid rgba(255,255,255,.06); }
+.footer-inner { display: grid; grid-template-columns: 1.5fr 1fr; gap: 16px; align-items: center; }
+.footer-nav { display: flex; gap: 12px; list-style: none; padding: 0; margin: 0; }
+.footer-nav a { color: var(--muted); text-decoration: none; }
+.footer-nav a:hover { color: var(--text); }
+
+/* Utilities */
+.grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; align-items: start; }
+.show-md { display: none; }
+
+/* Responsive */
+@media (max-width: 920px) {
+  .hero .grid-2, .grid-2, .cards, .gallery, .quotes, .cta .grid-2, .footer-inner, .fields { grid-template-columns: 1fr; }
+  .cta-actions { text-align: left; }
+  .site-nav { position: fixed; inset: 64px 0 auto 0; padding: 16px 20px; background: rgba(10,12,16,.95); border-bottom: 1px solid rgba(255,255,255,.06); transform: translateY(-120%); transition: transform .25s ease; flex-direction: column; gap: 14px; }
+  .site-nav.open { transform: translateY(0); }
+  .nav-toggle { display: inline-block; }
+  .show-md { display: inline; }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PrimeBuild Construction — Build It Right. On Time. On Budget.</title>
+  <meta name="description" content="Construction company website template: fast, accessible, mobile-first. Services, projects, testimonials, and contact form." />
+  <meta property="og:title" content="PrimeBuild Construction" />
+  <meta property="og:description" content="Trusted builders for residential and commercial projects." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="/" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='8' fill='%23000'/><path d='M10 46 L24 18 L40 46 L54 18' stroke='%23fff' stroke-width='6' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>">
+  <link rel="preload" href="/css/styles.css" as="style" />
+  <link rel="stylesheet" href="/css/styles.css" />
+  <script defer src="/js/main.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="#hero" aria-label="PrimeBuild Construction home">PrimeBuild<span>Construction</span></a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="#services">Services</a></li>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#testimonials">Testimonials</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+        <a class="btn btn-primary" href="#contact">Free Estimate</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section id="hero" class="hero section">
+      <div class="container grid-2">
+        <div class="hero-copy">
+          <h1>Build It Right.<br class="show-md" /> On Time. On Budget.</h1>
+          <p>Residential and commercial construction by a team that treats your project like our own.</p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="#contact">Get a Free Quote</a>
+            <a class="btn btn-ghost" href="#projects" aria-label="View past projects">See Our Work</a>
+          </div>
+          <ul class="badges" role="list">
+            <li>Licensed • Insured</li>
+            <li>20+ Years Experience</li>
+            <li>Local • Family-Owned</li>
+          </ul>
+        </div>
+        <div class="hero-media" aria-hidden="true">
+          <div class="hero-card">
+            <div class="hero-img" role="img" aria-label="Crew working on a modern home framing"></div>
+            <div class="hero-stats">
+              <div><strong>350+</strong><span>Projects delivered</span></div>
+              <div><strong>98%</strong><span>On-time completion</span></div>
+              <div><strong>4.9★</strong><span>Average rating</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="services" class="services section">
+      <div class="container">
+        <h2 class="section-title">Services</h2>
+        <p class="section-lead">From planning to punch list—we manage it all with clear communication and quality craftsmanship.</p>
+        <div class="cards">
+          <article class="card">
+            <h3>General Contracting</h3>
+            <p>Full‑service management for residential and commercial builds.</p>
+          </article>
+          <article class="card">
+            <h3>Remodeling</h3>
+            <p>Kitchens, bathrooms, basements, and whole‑home renovations.</p>
+          </article>
+          <article class="card">
+            <h3>Roofing & Siding</h3>
+            <p>Durable materials, clean installs, and strong warranties.</p>
+          </article>
+          <article class="card">
+            <h3>Concrete</h3>
+            <p>Foundations, driveways, slabs, and decorative finishes.</p>
+          </article>
+          <article class="card">
+            <h3>Electrical</h3>
+            <p>Licensed pros for safe, up‑to‑code wiring and panel upgrades.</p>
+          </article>
+          <article class="card">
+            <h3>Plumbing</h3>
+            <p>New installs and remodel re‑routes with clean, leak‑free results.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="projects" class="projects section">
+      <div class="container">
+        <h2 class="section-title">Recent Projects</h2>
+        <div class="gallery">
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Modern kitchen remodel"></div>
+            <figcaption>Modern Kitchen Remodel</figcaption>
+          </figure>
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Custom home build"></div>
+            <figcaption>Custom Home Build</figcaption>
+          </figure>
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Concrete driveway & steps"></div>
+            <figcaption>Concrete Driveway &amp; Steps</figcaption>
+          </figure>
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Commercial tenant finish"></div>
+            <figcaption>Commercial Tenant Finish</figcaption>
+          </figure>
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Roofing replacement"></div>
+            <figcaption>Roofing Replacement</figcaption>
+          </figure>
+          <figure class="project">
+            <div class="placeholder" role="img" aria-label="Siding & exterior upgrades"></div>
+            <figcaption>Siding &amp; Exterior Upgrades</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section id="testimonials" class="testimonials section">
+      <div class="container">
+        <h2 class="section-title">What Clients Say</h2>
+        <div class="quotes">
+          <blockquote>
+            <p>“PrimeBuild finished our renovation ahead of schedule and the quality is outstanding.”</p>
+            <footer>— Amelia R.</footer>
+          </blockquote>
+          <blockquote>
+            <p>“Clear communication, fair pricing, and a spotless job site. Highly recommend.”</p>
+            <footer>— Marcus D.</footer>
+          </blockquote>
+          <blockquote>
+            <p>“They handled permits and inspections seamlessly. Zero surprises.”</p>
+            <footer>— Tiana S.</footer>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+
+    <section id="cta" class="cta section">
+      <div class="container grid-2">
+        <div>
+          <h2>Ready to build?</h2>
+          <p>Tell us about your project goals and we’ll get you a same‑day estimate.</p>
+        </div>
+        <div class="cta-actions">
+          <a class="btn btn-primary" href="#contact">Start Your Quote</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="contact section">
+      <div class="container">
+        <h2 class="section-title">Contact</h2>
+        <form id="quoteForm" class="form" method="POST" action="#">
+          <!-- To wire up later: replace action with your provider endpoint (e.g., Formspree, serverless function) -->
+          <div class="fields">
+            <div class="field">
+              <label for="name">Name</label>
+              <input id="name" name="name" type="text" autocomplete="name" required />
+            </div>
+            <div class="field">
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" autocomplete="email" required />
+            </div>
+            <div class="field">
+              <label for="phone">Phone</label>
+              <input id="phone" name="phone" type="tel" autocomplete="tel" />
+            </div>
+            <div class="field full">
+              <label for="message">Project details</label>
+              <textarea id="message" name="message" rows="6" placeholder="Tell us about your project…" required></textarea>
+            </div>
+          </div>
+          <div class="form-actions">
+            <button class="btn btn-primary" type="submit">Request Estimate</button>
+            <p class="form-note">By submitting, you agree to be contacted about your request.</p>
+          </div>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div>
+        <h3>PrimeBuild Construction</h3>
+        <p>Licensed & Insured • Serving your area</p>
+        <p><a href="mailto:info@example.com">info@example.com</a> • (555) 123‑4567</p>
+      </div>
+      <nav aria-label="Footer">
+        <ul class="footer-nav">
+          <li><a href="#services">Services</a></li>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#testimonials">Testimonials</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+      <p class="copyright">© <span id="year"></span> PrimeBuild Construction. All rights reserved.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const year = document.getElementById('year');
+  if (year) year.textContent = new Date().getFullYear();
+
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('.site-nav');
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+
+  const form = document.getElementById('quoteForm');
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      // Simple client-side validation; replace with your form handler or serverless function.
+      const required = ['name', 'email', 'message'];
+      for (const id of required) {
+        const el = form.querySelector('#' + id);
+        if (!el || !el.value.trim()) {
+          e.preventDefault();
+          alert('Please fill out the required fields.');
+          el?.focus();
+          return;
+        }
+      }
+      // If using a provider like Formspree, set the form.action to their endpoint.
+    });
+  }
+});

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,17 @@
+# PR: Add static construction site starter
+
+## Summary
+Adds a fast, accessible static starter for the construction website:
+- Hero, Services, Projects, Testimonials, Contact
+- `vercel.json` with clean URLs + long‑term caching for static assets
+- `robots.txt` and `sitemap.xml`
+- PR template
+
+## Screenshots / Demos
+- Vercel Preview URL: _will appear on this PR after CI runs_
+
+## Checklist
+- [ ] Smoke‑tested locally (links, nav, form)
+- [ ] Replaced placeholder contact email/phone
+- [ ] Updated colors/branding
+- [ ] Replaced project images

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)\\.(css|js|png|jpg|jpeg|gif|svg|webp|ico)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# PR: Add static construction site starter

## Summary
Adds a fast, accessible static starter for the construction website:
- Hero, Services, Projects, Testimonials, Contact
- `vercel.json` with clean URLs + long‑term caching for static assets
- `robots.txt` and `sitemap.xml`
- PR template

## Screenshots / Demos
- Vercel Preview URL: _will appear on this PR after CI runs_

## Checklist
- [ ] Smoke‑tested locally (links, nav, form)
- [ ] Replaced placeholder contact email/phone
- [ ] Updated colors/branding
- [ ] Replaced project images
